### PR TITLE
Handle binary and non-jms header names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target/
+.tool-versions
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>amazon-sqs-java-messaging-lib</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <packaging>jar</packaging>
   <name>Amazon SQS Java Messaging Library</name>
   <description>The Amazon SQS Java Messaging Library holds the Java Message Service compatible classes, that are used

--- a/pom.xml
+++ b/pom.xml
@@ -127,24 +127,24 @@
            <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-            <configuration>
-              <keyname>${gpg.sqs.keyname}</keyname>
-              <passphraseServerId>gpg.sqs.passphrase</passphraseServerId>
-              <skip>true</skip>
-      	    </configuration>
-          </execution>
-        </executions>
-      </plugin>
+<!--      <plugin>-->
+<!--        <groupId>org.apache.maven.plugins</groupId>-->
+<!--        <artifactId>maven-gpg-plugin</artifactId>-->
+<!--        <executions>-->
+<!--          <execution>-->
+<!--            <id>sign-artifacts</id>-->
+<!--            <phase>verify</phase>-->
+<!--            <goals>-->
+<!--              <goal>sign</goal>-->
+<!--            </goals>-->
+<!--            <configuration>-->
+<!--              <keyname>${gpg.sqs.keyname}</keyname>-->
+<!--              <passphraseServerId>gpg.sqs.passphrase</passphraseServerId>-->
+<!--              <skip>true</skip>-->
+<!--      	    </configuration>-->
+<!--          </execution>-->
+<!--        </executions>-->
+<!--      </plugin>-->
     </plugins>
   </build>
   

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSMessagingClientConstants.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSMessagingClientConstants.java
@@ -52,6 +52,8 @@ public class SQSMessagingClientConstants {
 
     public static final String SHORT = "Number.short";
 
+    public static final String BINARY = "Binary";
+
     public static final String INT_FALSE = "0";
 
     public static final String INT_TRUE = "1";

--- a/src/test/java/com/amazon/sqs/javamessaging/message/SQSMessageTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/message/SQSMessageTest.java
@@ -448,6 +448,43 @@ public class SQSMessageTest {
      * Test using SQS message attribute during SQS Message constructing
      */
     @Test
+    public void testSQSUnknownType() throws JMSException {
+
+        Acknowledger ack = mock(Acknowledger.class);
+
+        Map<String,String> systemAttributes = new HashMap<String, String>();
+        systemAttributes.put(APPROXIMATE_RECEIVE_COUNT, "100");
+
+        Map<String, MessageAttributeValue> messageAttributes = new HashMap<String, MessageAttributeValue>();
+
+        messageAttributes.put(myString, new MessageAttributeValue()
+                .withDataType(SQSMessagingClientConstants.STRING)
+                .withStringValue("StringValue"));
+
+        messageAttributes.put("arbitrary", new MessageAttributeValue()
+                .withDataType("Arbitrary")
+                .withStringValue("ArbitraryValue"));
+
+        com.amazonaws.services.sqs.model.Message sqsMessage = new com.amazonaws.services.sqs.model.Message()
+                .withMessageAttributes(messageAttributes)
+                .withAttributes(systemAttributes)
+                .withMessageId("messageId")
+                .withReceiptHandle("ReceiptHandle");
+
+        boolean caught = false;
+        try {
+            SQSMessage message = new SQSMessage(ack, "QueueUrl", sqsMessage);
+        } catch (JMSException e) {
+            caught = true;
+        }
+
+        assertTrue(caught);
+    }
+
+    /**
+     * Test using SQS message attribute during SQS Message constructing
+     */
+    @Test
     public void testSQSMessageAttributeRenaming() throws JMSException {
 
         Acknowledger ack = mock(Acknowledger.class);


### PR DESCRIPTION
This Pull Request uses a branch-fork from the last aws-sdk v1 tag from the upstream library. We can use this branch to maintain any fixes until all v1 uses are deprecated and removed.

These changes should be able to port forward to the v2 branch at a later date.

The JMS consumer has a couple gotchas that can cause un-rescuable issues when consuming SQS messages from outside sources.

This PR tackles the following issues:

* SQS Header DataTypes that are not specifically handled cause an exception and are not processed.
    * This PR starts with a change to gracefully handle Binary header types by dropping them instead of throwing an exception. It is currently logging these incidents.
    * A next version of this fork will allow a 'user specified' handler to be registered to the consumer to handle these as necessary.
* Header fields must conform to the JMS standard (java-identifier, very similar to regex `\w` word characters)
    * This PR starts with a change to reformat key names not allowed by JMS (non-java-identifier, nominally `\W` regex)
    * A next version of this fork will allow a 'user specified' handler to rename and handle these keys

Relevant upstream tickets:

* https://github.com/awslabs/amazon-sqs-java-messaging-lib/issues/50
* https://github.com/awslabs/amazon-sqs-java-messaging-lib/issues/53
* https://github.com/awslabs/amazon-sqs-java-messaging-lib/issues/54
* https://github.com/awslabs/amazon-sqs-java-messaging-lib/issues/98

Similar:
* https://github.com/awslabs/amazon-sqs-java-messaging-lib/pull/61